### PR TITLE
Añadiendo healtcheck y modificando puertos de arranque

### DIFF
--- a/conf/app.conf
+++ b/conf/app.conf
@@ -1,5 +1,5 @@
 appname = novedades_api
-httpport = ${NOVEDADES_API_HTTP_PORT}
+httpport = ${NOVEDADES_API_HTTP_PORT_1}
 runmode = dev
 autorender = false
 copyrequestbody = true

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"github.com/astaxie/beego"
 	"github.com/astaxie/beego/plugins/cors"
 	_ "github.com/udistrital/novedades_api/routers"
+	"github.com/udistrital/utils_oas/apiStatusLib"
 )
 
 func main() {
@@ -20,5 +21,6 @@ func main() {
 		AllowCredentials: true,
 	}))
 
+	apistatus.Init()
 	beego.Run()
 }


### PR DESCRIPTION
Se añade libreria que proporciona healtcheck de la API para subida a Amazon, ademas de reconfigurar el puerto por defecto de escucha. 